### PR TITLE
NRMC-435: Offline mode

### DIFF
--- a/docs/realtime/offline-mode.md
+++ b/docs/realtime/offline-mode.md
@@ -1,0 +1,63 @@
+---
+layout: docs
+title: Offline Mode
+---
+# Offline Mode
+
+A [Realtime](../realtime/realtime) instance can be started in offline mode without connecting to a server or any networking capabilities.
+
+It's useful for offline experiences like:
+* Tutorial
+* Practice against AI
+* Interactive main menu
+
+RealtimeComponents and other scripts that were developed for regular Normcore usage will function in this mode with no additional changes. This allows content and scripts to be re-used across online and offline experiences.
+
+## Usage
+When you connect to a room server using either `Connect()` on Realtime or Room, you can pass an optional `ConnectOptions` struct. This struct supports an optional `offlineMode` flag that will start an offline mode session when enabled:
+
+```csharp
+class ConnectionManager {
+    [SerializeField]
+    private Realtime _realtime;
+
+    private void Start() {
+        // Connect to "My Room" in offline mode
+        _realtime.Connect("My Room", new Room.ConnectOptions {
+            offlineMode = true
+        });
+    }
+}
+```
+
+`realtime.room.offlineMode` can be later queried to run offline-specific logic.
+
+:::warning
+Uncheck `Join Room on Start` on the `Realtime` component if you're going to manually call `Connect()` instead.
+:::
+
+## Details
+
+All views and components are locally owned.
+
+`Room.clientID` always returns `0`.
+
+`Room.time` uses the system clock.
+
+## Limitations
+
+A new room and datastore pair are created for each offline mode client.
+
+Connecting another client to the same room is not supported. A separate room/datastore is created even if the same room name is specified.
+
+## Lifetime
+
+When an offline mode client disconnects the `Room` and `Datastore` are destroyed. Custom persistence mechanisms (in-process or on disk) can be developed on top of existing Normcore API but do not come with offline mode out of the box.
+
+## Serialization
+
+:::warning
+The serialization and deserialization mechanisms are skipped in offline mode. So related events (ex `RealtimeModelEvent.OnWillWrite`) will not be invoked.
+
+User scripts may be affected in the rare case where they rely on serialization events to drive local simulation.
+:::

--- a/docs/room/offline-mode.md
+++ b/docs/room/offline-mode.md
@@ -55,9 +55,9 @@ Connecting another client to the same room is not supported. Even when the same 
 
 ## Lifetime
 
-The offline mode datastore is only stored in-memory, and is tied to the lifetime of its `Room` C# object. The `Disconnect()` function on Realtime and Room will also clear its datastore.
+The datastore state of an offline room is cleared upon calling `Disconnect()`.
 
-Custom persistence mechanisms (in-memory or on disk) can be developed on top of existing Normcore API but do not come with offline mode out of the box.
+Custom persistence mechanisms (in-memory or on disk) can be developed on top of existing Normcore API.
 
 ## Serialization
 

--- a/docs/room/offline-mode.md
+++ b/docs/room/offline-mode.md
@@ -51,13 +51,13 @@ All views and components are locally owned.
 
 ## Limitations
 
-Connecting another client to the same room is not supported. Even when the same room name is specified no data is shared between the rooms/datastores.
+Connecting another client to the same room is not supported. Even when the same room name is specified no data is shared between the rooms.
 
 ## Lifetime
 
-When an offline mode client disconnects the `Room` and `Datastore` are destroyed.
+The offline mode datastore is only stored in-memory, and is tied to the lifetime of its `Room` C# object. The `Disconnect()` function on Realtime and Room will also clear its datastore.
 
-Custom persistence mechanisms (in-process or on disk) can be developed on top of existing Normcore API but do not come with offline mode out of the box.
+Custom persistence mechanisms (in-memory or on disk) can be developed on top of existing Normcore API but do not come with offline mode out of the box.
 
 ## Serialization
 

--- a/docs/room/offline-mode.md
+++ b/docs/room/offline-mode.md
@@ -4,7 +4,7 @@ title: Offline Mode
 ---
 # Offline Mode
 
-A [Realtime](../realtime/realtime) instance can be started in offline mode without connecting to a server or any networking capabilities.
+A Realtime or Room can be started in offline mode without connecting to a server or any networking capabilities.
 
 It's useful for offline experiences like:
 * Tutorial
@@ -14,7 +14,7 @@ It's useful for offline experiences like:
 RealtimeComponents and other scripts that were developed for regular Normcore usage will function in this mode with no additional changes. This allows content and scripts to be re-used across online and offline experiences.
 
 ## Usage
-When you connect to a room server using either `Connect()` on Realtime or Room, you can pass an optional `ConnectOptions` struct. This struct supports an optional `offlineMode` flag that will start an offline mode session when enabled:
+When you connect using `Connect()` on either Realtime or Room, you can pass an optional `ConnectOptions` struct. This struct supports an optional `offlineMode` flag that will start an offline mode session when enabled:
 
 ```csharp
 class ConnectionManager {
@@ -27,10 +27,15 @@ class ConnectionManager {
             offlineMode = true
         });
     }
+    
+    private void Update {
+        // Check if running in offline mode, ex for offline-specific logic
+        if (_realtime.connected && _realtime.room.offlineMode) {
+            Debug.Log($"Running in offline mode");
+        }
+    }
 }
 ```
-
-`realtime.room.offlineMode` can be later queried to run offline-specific logic.
 
 :::warning
 Uncheck `Join Room on Start` on the `Realtime` component if you're going to manually call `Connect()` instead.
@@ -46,13 +51,13 @@ All views and components are locally owned.
 
 ## Limitations
 
-A new room and datastore pair are created for each offline mode client.
-
-Connecting another client to the same room is not supported. A separate room/datastore is created even if the same room name is specified.
+Connecting another client to the same room is not supported. Even when the same room name is specified no data is shared between the rooms/datastores.
 
 ## Lifetime
 
-When an offline mode client disconnects the `Room` and `Datastore` are destroyed. Custom persistence mechanisms (in-process or on disk) can be developed on top of existing Normcore API but do not come with offline mode out of the box.
+When an offline mode client disconnects the `Room` and `Datastore` are destroyed.
+
+Custom persistence mechanisms (in-process or on disk) can be developed on top of existing Normcore API but do not come with offline mode out of the box.
 
 ## Serialization
 

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -94,6 +94,7 @@ const sidebars: SidebarsConfig = {
         'realtime/realtimetransform',
         'realtime/synchronizing-custom-data',
         'realtime/networked-physics',
+        'realtime/offline-mode',
         'realtime/common-questions',
         {
           type: 'category',

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -94,7 +94,6 @@ const sidebars: SidebarsConfig = {
         'realtime/realtimetransform',
         'realtime/synchronizing-custom-data',
         'realtime/networked-physics',
-        'realtime/offline-mode',
         'realtime/common-questions',
         {
           type: 'category',
@@ -119,6 +118,7 @@ const sidebars: SidebarsConfig = {
         'room/collections',
         'room/ownership-and-lifetime-flags',
         'room/room-server-options',
+        'room/offline-mode',
         'room/common-questions',
       ]
     },


### PR DESCRIPTION
Wondering if it should be in the `Realtime API` section or in the `Room + Datastore API` section.

The sample code was adapted from https://normcore.io/documentation/room/room-server-options#using-room-server-options-on-connect