### PR TITLE
NRMC-1402: Update links for samples

### DIFF
--- a/docs/guides/creating-a-multiplayer-drawing-app.md
+++ b/docs/guides/creating-a-multiplayer-drawing-app.md
@@ -23,7 +23,7 @@ In this guide I’m going to show you how to make a simple multiplayer drawing a
 
 First, we’ll walk through how the singleplayer brush example works, and then we’ll walk through how to make it multiplayer using Normcore.
 
-To start, download the project template [here](</downloads/Normcore Multiplayer Drawing-Singleplayer.zip>). This project includes the implementation for a basic VR brush in Unity.
+To start, download the Multiplayer Drawing Singleplayer project template from the [Normcore Samples repository](https://github.com/NormalVR/Normcore-Samples). This project template implements a basic VR brush in Unity.
 
 Once you have the project open, open up the Brush scene. You should see a Brush object in the scene. First, let’s try it out. Make a note of which hand the Brush script is set to, hit Play, and use the trigger to draw:
 
@@ -1135,7 +1135,7 @@ And we’re done! Let’s test it out!
 
 Works like a charm! Export a build and send it to a friend. You’ll both be able to join the same space and draw with each other :)
 
-You can download the complete project [here](</downloads/Normcore Multiplayer Drawing-Multiplayer.zip>).
+You can download the complete project from the [Normcore Samples repository](https://github.com/NormalVR/Normcore-Samples).
 
 Fun things to try now:
 

--- a/docs/guides/recipes/rpc-events.md
+++ b/docs/guides/recipes/rpc-events.md
@@ -19,7 +19,7 @@ This recipe shows how to use a model to send an RPC-like event message that can 
 
 For this example, let's say we want to trigger a celebration particle system effect on all clients. We'll want to send an RPC-like message that includes the sender ID, position, and scale of the effect. Typically I'd recommend instantiating a particle system prefab, but if you *absolutely have to* use an RPC-like structure, here's how you can do it:
 
-Let's start with the [template project](</downloads/Normcore RPC Events Recipe Template.zip>). Open up the scene located in the `_RPC Events Recipe` folder. This is an empty scene with a prebuilt particle system called **Explosion Particle System**. We can test it out by entering play mode and then clicking Emit in the inspector:
+Let's start with the RPC Events Recipe template project that can be downloaded from the [Normcore Samples repository](https://github.com/NormalVR/Normcore-Samples). Open up the scene located in the `_RPC Events Recipe` folder. This is an empty scene with a prebuilt particle system called **Explosion Particle System**. We can test it out by entering play mode and then clicking Emit in the inspector:
 
 <video width="100%" controls><source src={particleSystemTest} /></video>
 
@@ -39,7 +39,7 @@ This model includes the trigger integer that we'll use to trigger the event, the
 
 Go into the Unity editor and compile this model so we can start using the public properties on it. Once it's compiled, we'll add a method and C# event to let us fire the event and listen for when it's fired:
 
-```csharp{8-25}
+```csharp {8-25}
 [RealtimeModel]
 public partial class ExplosionEventModel {
     [RealtimeProperty(1, true)] private int     _trigger;
@@ -60,8 +60,8 @@ public partial class ExplosionEventModel {
     public event EventHandler eventDidFire;
 
     // A RealtimeCallback method that fires whenever we read any values from the server
-    [RealtimeCallback(RealtimeModelEvent.OnDidRead)]
-    private void DidRead() {
+    [RealtimeCallback(RealtimeModelEvent.OnDidReadModel)]
+    private void OnDidReadModel(PropertyChangeSet changeSet) {
         if (eventDidFire != null && trigger != 0)
             eventDidFire(senderID, position, scale);
     }
@@ -135,4 +135,4 @@ Create an empty game object, add both scripts, wire up the particle system refer
 
 That's it! Despite having a nice recipe for this, I still recommend avoiding this pattern if you can. Any state that is modified in response to an event like this can easily diverge between clients. There are circumstances where it can make sense, but in most cases it will lead to desyncs and bugs that are hard to test for and reproduce.
 
-If you'd like to check out the completed recipe project, you can download it [here](</downloads/Normcore RPC Events Recipe Complete.zip>).
+If you'd like to check out the completed recipe project, you can find it in the [Normcore Samples repository](https://github.com/NormalVR/Normcore-Samples).

--- a/docs/guides/recipes/using-addressables.md
+++ b/docs/guides/recipes/using-addressables.md
@@ -143,4 +143,4 @@ Throw this script on an empty game object in the scene and wire up the realtime 
 
 As soon as Realtime connects to the room server, our test script will `Realtime.Instantiate` our test asset, and we'll see it show up in the scene.
 
-Download the complete [Normcore Addressables Recipe](</downloads/Normcore Addressables Recipe.zip>) project and try it out for yourself.
+Download the complete Addressables Recipe from the [Normcore Samples repository](https://github.com/NormalVR/Normcore-Samples) project and try it out for yourself.

--- a/docs/guides/using-ar-as-a-spectator-view.md
+++ b/docs/guides/using-ar-as-a-spectator-view.md
@@ -57,6 +57,8 @@ Now head back to Unity and open up the original “Realtime + VR Player” scene
 
 Boooooom!! Easy.
 
+You can download the complete project from the [Normcore Samples repository](https://github.com/NormalVR/Normcore-Samples).
+
 Want to take this a step further? Try creating a custom avatar for your AR Spectator so they look different than the VR players in VR. Check out our other guides for synchronizing custom data too!
 
 - [XR Avatars and Voice Chat](./xr-avatars-and-voice-chat.md)

--- a/docs/realtime/synchronizing-custom-data.md
+++ b/docs/realtime/synchronizing-custom-data.md
@@ -302,7 +302,7 @@ Export a standalone build and make sure your scene’s camera is pointed at the 
 
 Now we can open that standalone build, hit play in the editor, and change the cube color. Go ahead and try it. We’ll see the standalone build’s cube color update in real-time.
 
-Download a finished copy of the project [here](</downloads/Normcore Synchronizing Custom Data.zip>).
+Download a finished copy of the Synchronizing Custom Data project from the [Normcore Samples repository](https://github.com/NormalVR/Normcore-Samples).
 
 Check out our other guides on synchronizing custom data:
 


### PR DESCRIPTION
I can't think of a sustainable way to have individual links for samples. Introducing the "Normal Samples repository" instead and changing the wording so it's clear that any given sample/template is one of many. On the bright side the README and the full list of samples are directly accessible.

A few non-blocking issues remain:
* The AR Spectator guide relies on a .unitypackage which isn't compatible with the repo approach. Can fix in a separate task.
* The RPC guide uses 2019 manually compiled models. Can fix in a separate task.

Did not delete the zip files themselves:
* Someone somewhere is maybe still linking to them
* The AR spectator guide still relies on the .unitypackage