### PR TITLE
RF1R: Add ConnectDirectlyToQuickmatchRoom webhook docs

### DIFF
--- a/docs/guides/quickmatch.md
+++ b/docs/guides/quickmatch.md
@@ -93,6 +93,10 @@ As long as the room has capacity, anyone can join.
 This method can result in a [`QuickmatchRoomNotFound`](../room/disconnect-events#quickmatchroomnotfound) disconnect event if the room has been cleaned up, or a [`QuickmatchRoomFull`](../room/disconnect-events#quickmatchroomfull) event if the room is at capacity. See [Error Handling](#error-handling) for how to handle these cases.
 :::
 
+:::note
+If you're using [Normcore Private webhooks](../normcore-private/webhooks), all quickmatch connection methods are verified by the webhook before a room slot is reserved. See the [webhooks documentation](../normcore-private/webhooks#quickmatch-webhook-behavior) for details.
+:::
+
 ### Room Properties
 
 After connecting to a Quickmatch room, you can access the room code and capacity via the `Room` object:


### PR DESCRIPTION
## Summary
- Add `ConnectDirectlyToQuickmatchRoom` as a documented webhook action
- Add quickmatch request example showing `roomGroupName` + `roomCode` fields
- Document the two-webhook sequence for quickmatch connections (quickmatch-specific webhook fires first, then `ConnectToRoom`)
- Add cross-reference note in quickmatch guide pointing to webhook docs

Addresses feedback from https://github.com/NormalVR/Normcore-Matcher/pull/100#discussion_r2743208184